### PR TITLE
Fixed childprocess fork args

### DIFF
--- a/backEnd/routes/play.js
+++ b/backEnd/routes/play.js
@@ -9,9 +9,7 @@ var childProcess = require("child_process");
 function runScript(scriptPath, jsonArg, errLogCallback) {
   var invoked = false;
 
-  var process = childProcess.fork(scriptPath, {
-    execArgv: ["--" + jsonArg]
-  });
+  var process = childProcess.fork(scriptPath, ['playback', '--json', jsonArg]);
 
   // listen for errors as they may prevent the exit event from firing
   process.on("error", function(err) {


### PR DESCRIPTION
This will call yield the equivalent of the following console command:

node Playback.js playback --json \<json str\>

Break down of command:
node Playback.js - runs playback script
playback - chooses which path to run in Playback.js (currently you can call it with jobs to list all capture jobs, or playback to play a job back)
--json \<json str\> - takes in the json string parameter