### PR TITLE
Playback fixes

### DIFF
--- a/Playback.js
+++ b/Playback.js
@@ -240,6 +240,7 @@ if(args._.includes('playback')) {
             //Select the correct request class
             let webreq = editable_options['secure'] ? https : http;
             req_options.port = editable_options['secure'] ? cmd_options.secure_port : cmd_options.port;
+            req_options.headers.Host = cmd_options.hostname;
             let req;
             try {
                 req = webreq.request(req_options, (res) => {

--- a/Playback.js
+++ b/Playback.js
@@ -92,7 +92,7 @@ const args = require('yargs')
             type: 'count'
         });
         yargs.options('playback-speed', {
-            alias: 'p',
+            alias: 'ps',
             desc: 'specifies the speed at which requests are played back',
             type: 'number'
         });
@@ -146,7 +146,7 @@ if(args._.includes('playback')) {
         playbackSpeed: 1,
         hostname: 'localhost',
         port: 8080,
-        securePort: 443,
+        securePort: 4443,
         requestBufferTime: 10000
     };
 
@@ -239,20 +239,25 @@ if(args._.includes('playback')) {
         if(editable_options.send_request === true) {
             //Select the correct request class
             let webreq = editable_options['secure'] ? https : http;
-	        req_options.port = editable_options['secure'] ? cmd_options.secure_port : cmd_options.port;
-            let req = webreq.request(req_options, (res) => {
-                // Code for testing
-                // res.setEncoding("utf-8")
-                // res.on('data', (data)=>{/*console.log(data)*/})
-                // res.on('end', ()=>{console.log("Finished streaming data for request response.")})
+            req_options.port = editable_options['secure'] ? cmd_options.secure_port : cmd_options.port;
+            let req;
+            try {
+                req = webreq.request(req_options, (res) => {
+                    // Code for testing
+                    // res.setEncoding("utf-8")
+                    // res.on('data', (data)=>{/*console.log(data)*/})
+                    // res.on('end', ()=>{console.log("Finished streaming data for request response.")})
 
-                request_callback_hook(res);
-            }); //Create the request
+                    request_callback_hook(res);
+                }); //Create the request
 
             if(editable_options['reqbody'] != "")
                 req.write(options.reqbody);
                 post_request_hook(req, options);
                 req.end();
+            } catch(err) {
+                console.log(err);
+            }
         }
     }
 

--- a/Playback.js
+++ b/Playback.js
@@ -144,7 +144,7 @@ if(args._.includes('playback')) {
     let default_options = {
         verbose: 0,
         playbackSpeed: 1,
-        hostname: 'localhost',
+        hostname: 'cascadevinyls.com',
         port: 8080,
         securePort: 4443,
         requestBufferTime: 10000

--- a/Playback.js
+++ b/Playback.js
@@ -144,9 +144,9 @@ if(args._.includes('playback')) {
     let default_options = {
         verbose: 0,
         playbackSpeed: 1,
-        hostname: 'cascadevinyls.com',
+        hostname: 'localhost',
         port: 8080,
-        securePort: 4443,
+        securePort: 8443,
         requestBufferTime: 10000
     };
 


### PR DESCRIPTION
1.) Fixed alias collision with playback-speed and port
2.) Did a hacky fix to make it so paths with 'unescaped characters' (I think it means spaces) don't error out when sending requests
3.) Fixed issue where req_options.host would be different than req_options.headers.Host (this would cause SSL errors if the header's Host option wasn't part of the recognized domains? host names)